### PR TITLE
build: Remove su inclusion

### DIFF
--- a/target/product/base_system.mk
+++ b/target/product/base_system.mk
@@ -378,7 +378,6 @@ PRODUCT_PACKAGES_DEBUG := \
     ss \
     start_with_lockagent \
     strace \
-    su \
     sanitizer-status \
     tracepath \
     tracepath6 \


### PR DESCRIPTION
This stops including su in all lineage userdebug/eng builds.
Inclusion of su is conditionally handled in /vendor/lineage.

Change-Id: Ia3ad978146f170a2b260d77afe9eb580d4b4f823