### PR TITLE
Trying to call GmsCompat to be built from here breaks raven compile

### DIFF
--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -49,7 +49,6 @@ PRODUCT_PACKAGES += \
     EasterEgg \
     ExternalStorageProvider \
     FusedLocation \
-    GmsCompat \
     InputDevices \
     KeyChain \
     librs_jni \


### PR DESCRIPTION
GSI devices don't like this here

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>